### PR TITLE
First proposal for the MixedMapper and MixedOp

### DIFF
--- a/qiskit_nature/second_q/mappers/__init__.py
+++ b/qiskit_nature/second_q/mappers/__init__.py
@@ -90,6 +90,17 @@ after the mapping to qubit operators, you can use the following wrapper for symm
 
    TaperedQubitMapper
 
+   
+MixedOp Mappers
++++++++++++++++
+
+.. autosummary::
+   :toctree: ../stubs/
+   :nosignatures:
+
+   MixedMapper
+
+
 Qubit Converter
 +++++++++++++++
 
@@ -113,6 +124,7 @@ from .qubit_mapper import QubitMapper
 from .qubit_converter import QubitConverter
 from .interleaved_qubit_mapper import InterleavedQubitMapper
 from .tapered_qubit_mapper import TaperedQubitMapper
+from .mixed_mapper import MixedMapper
 
 __all__ = [
     "BravyiKitaevMapper",
@@ -123,6 +135,7 @@ __all__ = [
     "LinearMapper",
     "BosonicLinearMapper",
     "LogarithmicMapper",
+    "MixedMapper",
     "QubitConverter",
     "QubitMapper",
     "InterleavedQubitMapper",

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -1,0 +1,111 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021, 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Spin Mapper."""
+
+from __future__ import annotations
+
+from qiskit.opflow import PauliSumOp
+from qiskit.quantum_info import SparsePauliOp
+
+from qiskit_nature.second_q.operators import SpinOp, MixedOp
+
+from .qubit_mapper import ListOrDictType, QubitMapper
+
+
+class MixedMapper(QubitMapper):
+    """Mapper of a Mixed Operator to a Qubit Operator.
+
+    This class is intended to be used for handling the mapping of composed fermionic and (or) bosonic
+    systems, defined as :class:`~qiskit_nature.second_q.operators.MixedOp`, into qubit operators.
+
+    Please note that the creation and usage of this class requires the precise definition of the
+    composite Hilbert size corresponding to the problem. It is expected that this "global" Hilbert space
+    will result in the tensor product of one or multiple "local" Hilbert spaces, where the ordering of
+    the "local" Hilbert spaces must be provided by the user and will correspond to the ordering of the
+    corresponding qubit registers before their concatenation.
+
+    The following attributes can be read and updated once the ``TaperedQubitMapper`` object has been
+    constructed.
+
+    Attributes:
+        mappers: Dictionary of mappers to associate to each "local" Hilbert spaces of the global problem.
+    """
+
+    def __init__(
+        self,
+        mappers: dict[str, QubitMapper],
+    ):
+        """
+        Args:
+            mappers: Dictionary of the mappers corresponding to each of the "local" Hilbert spaces.
+        """
+        super().__init__()
+        self.mappers = mappers
+
+    def _map_tuple_product(self, key, operator_tuple, hilbert_space_registers):
+        """Mapping of operator products."""
+        # initialize with the identity operator in the "global" Hilbert space.
+        coefficient = operator_tuple[0]
+        dict_mapped_op = {}
+        for key_temp, length in hilbert_space_registers.items():
+            dict_mapped_op[key_temp] = SparsePauliOp("I" * length, coeffs=coefficient)
+
+        # for each Hilbert space appearing in the product of operators, replace the identity with the
+        # corresponding term.
+        for index, op in enumerate(operator_tuple[1:]):
+            key_char = key[index]
+            mapper = self.mappers[key_char]
+            dict_mapped_op[key_char] = mapper.map(op)  # TODO: compose()
+
+        # tensor all the elements of the dictionary.
+        list_op = list(dict_mapped_op.values())
+        product_op = coefficient * list_op[0]
+        for op in list_op[1:]:
+            product_op = product_op.tensor(op)
+
+        return product_op  # TODO: simplify()
+
+    def _map_list_sum(self, key, operator_list, hilbert_space_registers):
+        """Mapping of operators sums within same Hilbert spaces."""
+        final_op = sum(
+            self._map_tuple_product(key, operator_tuple, hilbert_space_registers)
+            for operator_tuple in operator_list
+        )
+        return final_op
+
+    def _map_dict_sum(self, operator_dict, hilbert_space_registers):
+        """Mapping of operators sums within various Hilbert spaces."""
+        final_op = sum(
+            self._map_list_sum(key, operator_tuple, hilbert_space_registers)
+            for key, operator_tuple in operator_dict.data.items()
+        )
+        return final_op
+
+    def map(
+        self,
+        mixed_op: MixedOp,
+        *,
+        hilbert_space_registers: dict[str, int],
+    ) -> SparsePauliOp:
+        """Map the :class:`~qiskit_nature.second_q.operators.MixedOp` into a qubit operator.
+
+        The ``MixedOp`` is a representation of sums of products of operators corresponding to different Hilbert spaces. The mapping procedure first runs through all of the terms to be summed, and then maps the operator product corresponding to each summand by tensoring the individually mapped operators.
+
+        Args:
+            hilbert_space_registers: Ordered dictionary attributing a register length to each of the
+                Hilbert space. Note that the ordering of the "local" Hilbert spaces in the dictionary
+                translates directly to the ordering of the corresponding qubit registers.
+        """
+
+        mapped_op = self._map_dict_sum(mixed_op, hilbert_space_registers)
+        return mapped_op

--- a/qiskit_nature/second_q/operators/__init__.py
+++ b/qiskit_nature/second_q/operators/__init__.py
@@ -30,6 +30,7 @@ Operators and mappers for different systems such as fermionic, vibrational and s
    VibrationalIntegrals
    PolynomialTensor
    Tensor
+   MixedOp
 
 Modules
 -------
@@ -51,6 +52,7 @@ from .vibrational_integrals import VibrationalIntegrals
 from .polynomial_tensor import PolynomialTensor
 from .sparse_label_op import SparseLabelOp
 from .tensor import Tensor
+from .mixed_op import MixedOp
 
 __all__ = [
     "ElectronicIntegrals",
@@ -62,4 +64,5 @@ __all__ = [
     "PolynomialTensor",
     "SparseLabelOp",
     "Tensor",
+    "MixedOp",
 ]

--- a/qiskit_nature/second_q/operators/mixed_op.py
+++ b/qiskit_nature/second_q/operators/mixed_op.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from .sparse_label_op import SparseLabelOp
+from .fermionic_op import FermionicOp
+from .spin_op import SpinOp
+from typing import cast
+
+from abc import ABC, abstractmethod
+from collections.abc import Collection, Mapping
+
+from qiskit.quantum_info.operators.mixins import (
+    AdjointMixin,
+    GroupMixin,
+    LinearMixin,
+    TolerancesMixin,
+)
+
+from copy import deepcopy
+import numpy as np
+import itertools
+
+
+class MixedOp(LinearMixin):
+    """Mixed operator.
+
+    A ``MixedOp`` represents a weighted sum of products of fermionic/bosonic operators potentially
+    acting on different "local" Hilbert spaces. The terms to be summed are encoded in a dictionary,
+    where each operator product is identified by its key, a tuple of string specifying the names of the
+    local Hilbert spaces on which it acts, and by its value, a list of tuple (corresponding to a sum of
+    operators acting on the same composite Hilbert space) where each tuple encodes the coupling
+    coefficient and the operators themselves (that might also have coefficients asscociated with them).
+
+
+    **Initialization**
+
+    A ``MixedOp`` is initialized with a dictionary, mapping terms to their respective
+    coefficients:
+
+    .. code-block:: python
+
+    from qiskit_nature.second_q.operators import FermionicOp, MixedOp
+
+    fop1 = FermionicOp({"+_0 -_0": 1}) # Acting on Hilbert space "h1"
+    sop1 = SpinOp({"X_0 Y_0": 1}, num_spins=1) # Acting on Hilbert space "s1"
+
+    mop1 = MixedOp({("h1",): [(5.0, fop1)]}) # 5.0 * fop1
+    mop2 = MixedOp(
+        {
+            ("h1", "s1"): [(3, fop1, sop1)],
+            ("s1",): [(2, sop1)],
+        }
+    ) # 3*(fop1 @ sop1) + 2*(sop1)
+
+
+    .. note::
+    Note that the ``MixedOp`` objcet can be initialized without even knowing the structure of the
+    "global" Hilbert space of the problem. However, the user is expected to use an unambiguous naming
+    convention for the "local" Hilbert spaces to ensure a coherent construction.
+    A more precise specification of the "global' Hilbert space will be required for the mapping of the
+    ``MixedOp`` to qubit operators, setting the desired ordering and size of the registers corresponding
+    to each "local" Hilbert spaces.
+
+    **Algebra**
+
+    This class supports the following basic arithmetic operations: addition, subtraction, scalar
+    multiplication, operator multiplication.
+    For example,
+
+    Addition
+
+    .. code-block:: python
+
+        fop1 = FermionicOp({"+_0 -_0": 1}) # Acting on Hilbert space "h1"
+        sop1 = SpinOp({"X_0 Y_0": 1}, num_spins=1) # Acting on Hilbert space "s1"
+        MixedOp({("h1",): [(5.0, fop1)]}) + MixedOp({("s1",): [(6.0, sop1)]})
+
+      MixedOp({("h1",): [(5.0, fop1)], ("s1",): [(6.0, sop1)]})
+
+    Scalar multiplication
+
+    .. code-block:: python
+
+        fop1 = FermionicOp({"+_0 -_0": 1})
+        0.5 * MixedOp({("h1",): [(5.0, fop1)]})
+
+    Operator multiplication
+
+    .. code-block:: python
+
+        fop1 = FermionicOp({"+_0 -_0": 1}) # Acting on Hilbert space "h1"
+        sop1 = SpinOp({"X_0 Y_0": 1}, num_spins=1) # Acting on Hilbert space "s1"
+        MixedOp({("h1",): [(5.0, fop1)]}) @ MixedOp({("s1",): [(6.0, sop1)]})
+
+      MixedOp({("h1", "s1"): [(30.0, fop1, sop1)]})
+    """
+
+    def __init__(self, data=dict[tuple, list[tuple[SparseLabelOp, float]]]):
+        self.data = deepcopy(data)
+
+    def __repr__(self) -> str:
+        out_str = ""
+        for key, oplist in self.data.items():
+            for hspace in key:
+                out_str += hspace
+            out_str += " : "
+            for op_tuple in oplist:
+                out_str += "["
+                for op in op_tuple:
+                    out_str += f"{repr(op)} "
+                out_str += "]"
+            out_str += "\n"
+
+        return out_str
+
+    def keys_no_duplicate(self):
+        all_keys = ()
+        for key in self.data.keys():
+            all_keys += key
+        return tuple(set(all_keys))
+
+    @staticmethod
+    def _tuple_prod(tup1, tup2):
+        """Implements the composition of operator tuples representing tensor products of operators."""
+        new_coeff = tup1[0] * tup2[0]
+        new_op_tuple = tup1[1:] + tup2[1:]
+        return (new_coeff,) + new_op_tuple
+
+    @staticmethod
+    def _tuple_multiply(tup, coef):
+        """Implements the dilation by a coefficient of an operator tuple representing a tensor product
+        of operators."""
+        new_coeff = tup[0] * coef
+        return (new_coeff,) + tup[1:]
+
+    @staticmethod
+    def _tuple_conjugate(tup):
+        """Implements the conjugaison of an operator tuple representing a tensor product of operators."""
+        new_coeff = np.conjugate(tup[0])
+        new_op_tuple = tuple(op.conjugate() for op in tup[1:])
+        return (new_coeff,) + new_op_tuple
+
+    @staticmethod
+    def _tuple_transpose(tup):
+        """Implements the trasnsposition of an operator tuple representing a tensor product of
+        operators."""
+        new_coeff = tup[0]
+        new_op_tuple = tuple(op.transpose() for op in tup[1:])
+        return (new_coeff,) + new_op_tuple
+
+    @staticmethod
+    def _tuple_adjoint(tup):
+        """Implements the adjoint of an operator tuple representing a tensor product of operators."""
+        new_coeff = np.conjugate(tup[0])
+        new_op_tuple = tuple(op.adjoint() for op in tup[1:])
+        return (new_coeff,) + new_op_tuple
+
+    def _apply_on_tuples(self, method, *args, **kwargs) -> MixedOp:
+        new_op_data = {}
+        for key, op_tuple_list in self.data.items():
+            new_op_data[key] = [
+                method(op_tuple, *args, **kwargs) for op_tuple in op_tuple_list
+            ]
+        return MixedOp(new_op_data)
+
+    def conjugate(self):
+        """Returns the conjugate of the operator."""
+        return self._apply_on_tuples(MixedOp._tuple_conjugate)
+
+    def transpose(self):
+        """Returns the transpose of the operator."""
+        return self._apply_on_tuples(MixedOp._tuple_transpose)
+
+    def adjoint(self):
+        """Returns the adjoint of the operator."""
+        return self._apply_on_tuples(MixedOp._tuple_adjoint)
+
+    def _multiply(self, other: float):
+        """Return Operator multiplication of self and other.
+
+        Args:
+            other: the second ``MixedOp`` to multiply to the first.
+            qargs: UNUSED.
+
+        Returns:
+            The new multiplied ``MixedOp``.
+        """
+        return self._apply_on_tuples(MixedOp._tuple_multiply, other)
+
+    def _add(self, other: MixedOp, qargs: None = None) -> MixedOp:
+        """Return Operator addition of self and other.
+
+        Args:
+            other: the second ``MixedOp`` to add to the first.
+            qargs: UNUSED.
+
+        Returns:
+            The new summed ``MixedOp``.
+        """
+
+        sum_op = MixedOp(self.data)  # deepcopy
+        for key in other.data.keys():
+            # If the key for the composite Hilbert space already exists in the dictionary, then the
+            # addition is performed by appending the new operator to the corresponding list.
+            # Otherwise, the addition is performed by adding a new pair key, value to the dictionary.
+            if key in sum_op.data.keys():
+                sum_op.data[key] += other.data[key]
+            else:
+                sum_op.data[key] = other.data[key]
+        return sum_op
+
+    def compose(self, other: MixedOp) -> MixedOp:
+        """Returns Operator composition of self and other.
+
+        Args:
+            other: the other operator.
+            qargs: UNUSED.
+
+        Returns:
+            The operator resulting from the composition.
+        """
+
+        # Lazy composition without applying the products.
+        new_data = {}
+        for key1, key2 in itertools.product(self.data.keys(), other.data.keys()):
+            op_tuple_list1, op_tuple_list2 = self.data[key1], other.data[key2]
+            new_data[key1 + key2] = [
+                MixedOp._tuple_prod(op_tuple1, op_tuple2)
+                for op_tuple1, op_tuple2 in itertools.product(
+                    op_tuple_list1, op_tuple_list2
+                )
+            ]
+        return MixedOp(new_data)
+
+    def __eq__(self, other):
+        if self.data.keys() != other.data.keys():
+            return False
+        return all(
+            [self.data[key] == other.data[key] for key in self.data.keys()]
+        )

--- a/test/second_q/mappers/test_mixed_mapper.py
+++ b/test/second_q/mappers/test_mixed_mapper.py
@@ -1,0 +1,105 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+""" Test Mixed Mapper """
+
+import unittest
+
+
+from test import QiskitNatureTestCase
+
+from ddt import ddt, data, unpack
+import numpy as np
+
+from qiskit.quantum_info import SparsePauliOp
+from qiskit_nature.second_q.operators import BosonicOp, FermionicOp, MixedOp
+from qiskit_nature.second_q.mappers import (
+    BosonicLinearMapper,
+    JordanWignerMapper,
+    MixedMapper,
+)
+from qiskit_nature import settings
+
+
+@ddt
+class TestMixedMapper(QiskitNatureTestCase):
+    """Test Mixed Mapper"""
+
+    # Define some useful coefficients
+    sq_2 = np.sqrt(2)
+
+    bos_op1 = BosonicOp({"+_0": 1})
+    mapped_bos_op1 = SparsePauliOp(
+        ["XX", "YY", "YX", "XY"], coeffs=[0.25, 0.25, -0.25j, 0.25j]
+    )
+
+    bos_op2 = BosonicOp({"-_0": 1})
+    mapped_bos_op2 = SparsePauliOp(
+        ["XX", "YY", "YX", "XY"], coeffs=[0.25, 0.25, 0.25j, -0.25j]
+    )
+
+    fer_op1 = FermionicOp({"+_0": 1}, num_spin_orbitals=1)
+    mapped_fer_op1 = SparsePauliOp.from_list([("X", 0.5), ("Y", -0.5j)])
+
+    fer_op2 = FermionicOp({"-_0": 1}, num_spin_orbitals=1)
+    mapped_fer_op2 = SparsePauliOp.from_list([("X", 0.5), ("Y", 0.5j)])
+
+    bos_op5 = BosonicOp({"+_0 -_0": 1})
+    bos_op6 = BosonicOp({"-_0 +_0": 1})
+
+    bos_mapper = BosonicLinearMapper(max_occupation=1)
+    fer_mapper = JordanWignerMapper()
+    hilbert_space_registers = {"b1": 2, "f1": 1}
+    mappers = {"b1": bos_mapper, "f1": fer_mapper}
+    mix_mapper = MixedMapper(mappers=mappers)
+
+    def test_absolute_mapping(self):
+        """Test the ``MixedOp`` mapping and compare to the calculated values."""
+
+        target = self.mapped_bos_op1.tensor(3.0 * self.mapped_fer_op1)
+
+        aux = settings.use_pauli_sum_op
+        settings.use_pauli_sum_op = False
+        comp_op1 = MixedOp({("b1", "f1"): [(3.0, self.bos_op1, self.fer_op1)]})
+        test = self.mix_mapper.map(
+            comp_op1, hilbert_space_registers=self.hilbert_space_registers
+        )
+        settings.use_pauli_sum_op = aux
+
+        self.assertEqual(target, test)
+
+    @data(
+        (bos_op1, fer_op1, 2.0 + 1.0j),
+        (bos_op2, fer_op2, 3.0 + 2.0j),
+        (bos_op5, fer_op1, -4.0 - 3.0j),
+        (bos_op6, fer_op2, -5.0 + 4j),
+    )
+    @unpack
+    def test_relative_mapping(self, bos_op, fer_op, coef):
+        """Test the ``MixedOp`` mapping and compare to the composition of the mapped operators."""
+
+        composed_op = MixedOp({("b1", "f1"): [(coef, bos_op, fer_op)]})
+
+        aux = settings.use_pauli_sum_op
+        settings.use_pauli_sum_op = False
+        target = coef * self.bos_mapper.map(bos_op).tensor(self.fer_mapper.map(fer_op))
+        test = self.mix_mapper.map(
+            composed_op, hilbert_space_registers=self.hilbert_space_registers
+        )
+        settings.use_pauli_sum_op = aux
+        print(target)
+        print(test)
+        self.assertEqual(target, test)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/second_q/operators/test_mixed_op.py
+++ b/test/second_q/operators/test_mixed_op.py
@@ -1,0 +1,216 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021, 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test for MixedOp"""
+
+import unittest
+import warnings
+from test import QiskitNatureTestCase
+
+import numpy as np
+from ddt import data, ddt, unpack
+from qiskit.circuit import Parameter
+from scipy.sparse import csc_matrix
+from scipy.sparse.linalg import eigs
+
+from qiskit_nature.exceptions import QiskitNatureError
+from qiskit_nature.second_q.operators import FermionicOp, MixedOp
+import qiskit_nature.optionals as _optionals
+
+from qiskit_nature import settings
+
+
+@ddt
+class TestFermionicOp(QiskitNatureTestCase):
+    """FermionicOp tests."""
+
+    op1 = FermionicOp({"+_0 -_0": 1})
+    op2 = FermionicOp({"-_0 +_0": 2})
+    mop1_h1 = MixedOp({("h1",): [(2.0, op1)]})
+    mop2_h1 = MixedOp({("h1",): [(3.0, op2)]})
+    mop2_h2 = MixedOp({("h2",): [(3.0, op2)]})
+    sumop2 = MixedOp({("h1",): [(1, FermionicOp({"+_0 -_0": 2, "-_0 +_0": 3}))]})
+
+    def test_neg(self):
+        """Test __neg__"""
+        minus_mop1 = -self.mop1_h1
+        targ_v1 = MixedOp({("h1",): [(-2.0, self.op1)]})
+        self.assertEqual(minus_mop1, targ_v1)
+
+        # Requires the simplify()
+        # targ_v2 = MixedOp({("h1",): [(2.0, -self.op1)]})
+        # self.assertEqual(minus_mop1, targ_v2)
+
+        # fer_op = -self.op4
+        # targ = FermionicOp({"+_0 -_0": -self.a})
+        # self.assertEqual(fer_op, targ)
+
+    def test_mul(self):
+        """Test __mul__, and __rmul__"""
+        with self.subTest("rightmul"):
+            minus_mop1 = self.mop1_h1 * 2.0
+            targ_v1 = MixedOp({("h1",): [(4.0, self.op1)]})
+            self.assertEqual(minus_mop1, targ_v1)
+
+            # targ_v2 = MixedOp({("h1",): [(2.0, 2.0 * self.op1)]})
+            # self.assertEqual(minus_mop1, targ_v2)
+
+            # Requires the simplify()
+            # fer_op = self.op1 * self.a
+            # targ = FermionicOp({"+_0 -_0": self.a})
+            # self.assertEqual(fer_op, targ)
+
+        with self.subTest("leftmul"):
+            minus_mop1 = (2.0 + 1.0j) * self.mop1_h1
+            targ_v1 = MixedOp({("h1",): [((4.0 + 2.0j), self.op1)]})
+            self.assertEqual(minus_mop1, targ_v1)
+
+            # Requires the simplify()
+            # targ_v2 = MixedOp({("h1",): [(2.0, (2.0 + 1.0j) * self.op1)]})
+            # self.assertEqual(minus_mop1, targ_v2)
+
+    # def test_div(self):
+    #     """Test __truediv__"""
+    #     fer_op = self.op1 / 2
+    #     targ = FermionicOp({"+_0 -_0": 0.5}, num_spin_orbitals=1)
+    #     self.assertEqual(fer_op, targ)
+
+    #     fer_op = self.op1 / self.a
+    #     targ = FermionicOp({"+_0 -_0": 1 / self.a})
+    #     self.assertEqual(fer_op, targ)
+
+    def test_add(self):
+        """Test __add__"""
+        with self.subTest("same hilbert space"):
+            sum_mop = self.mop1_h1 + self.mop2_h1
+            targ = MixedOp({("h1",): [(2, self.op1), (3, self.op2)]})
+            self.assertEqual(sum_mop, targ)
+
+            # Requires the simplify()
+            # targ = self.sumop2
+            # self.assertEqual(sum_mop, targ)
+
+        with self.subTest("different hilbert space"):
+            sum_mop = self.mop1_h1 + self.mop2_h2
+            targ = MixedOp({("h1",): [(2.0, self.op1)], ("h2",): [(3.0, self.op2)]})
+            self.assertEqual(sum_mop, targ)
+
+        # with self.subTest("sum"):
+        #     fer_op = sum(FermionicOp({label: 1}) for label in ["+_0", "-_1", "+_2 -_2"])
+        #     targ = FermionicOp({"+_0": 1, "-_1": 1, "+_2 -_2": 1})
+        #     self.assertEqual(fer_op, targ)
+
+    def test_sub(self):
+        """Test __sub__"""
+        with self.subTest("same hilbert space"):
+            sum_mop = self.mop1_h1 - self.mop2_h1
+            targ = MixedOp({("h1",): [(2, self.op1), (-3, self.op2)]})
+            self.assertEqual(sum_mop, targ)
+
+            # Requires the simplify()
+            # targ = self.sumop2
+            # self.assertEqual(sum_mop, targ)
+
+        with self.subTest("different hilbert space"):
+            sum_mop = self.mop1_h1 - self.mop2_h2
+            targ = MixedOp({("h1",): [(2.0, self.op1)], ("h2",): [(-3.0, self.op2)]})
+            self.assertEqual(sum_mop, targ)
+
+    def test_compose(self):
+        """Test operator composition"""
+        with self.subTest("same hilbert spaces"):
+            composed_op = self.mop1_h1.compose(self.mop2_h1)
+            targ = MixedOp({("h1", "h1"): [(6.0, self.op1, self.op2)]})
+            self.assertEqual(composed_op, targ)
+
+        with self.subTest("different hilbert spaces"):
+            composed_op = self.mop1_h1.compose(self.mop2_h2)
+            targ = MixedOp({("h1", "h2"): [(6.0, self.op1, self.op2)]})
+            self.assertEqual(composed_op, targ)
+
+    def test_adjoint(self):
+        """Test adjoint method"""
+        test_adjoint = MixedOp(
+            {
+                ("h1",): [(2.0 + 1j, self.op1)],
+                (
+                    "h1",
+                    "h2",
+                ): [(3.0 +2j, self.op1, self.op2)],
+                "h2": [(4.0 -5j, self.op2)],
+            }
+        ).adjoint()
+
+        targ_adjoint = MixedOp(
+            {
+                ("h1",): [(2.0 - 1j, self.op1.adjoint())],
+                (
+                    "h1",
+                    "h2",
+                ): [(3.0 -2j, self.op1.adjoint(), self.op2.adjoint())],
+                "h2": [(4.0 +5j, self.op2.adjoint())],
+            }
+        )
+        self.assertEqual(test_adjoint, targ_adjoint)
+
+    def test_conjugate(self):
+        """Test conjugate method"""
+        test_conjugate = MixedOp(
+            {
+                ("h1",): [(2.0 + 1j, self.op1)],
+                (
+                    "h1",
+                    "h2",
+                ): [(3.0 +2j, self.op1, self.op2)],
+                "h2": [(4.0 -5j, self.op2)],
+            }
+        ).conjugate()
+
+        targ_conjugate = MixedOp(
+            {
+                ("h1",): [(2.0 - 1j, self.op1.conjugate())],
+                (
+                    "h1",
+                    "h2",
+                ): [(3.0 -2j, self.op1.conjugate(), self.op2.conjugate())],
+                "h2": [(4.0 +5j, self.op2.conjugate())],
+            }
+        )
+        self.assertEqual(test_conjugate, targ_conjugate)
+
+    def test_transpose(self):
+        """Test transpose method"""
+        test_transpose = MixedOp(
+            {
+                ("h1",): [(2.0 + 1j, self.op1)],
+                (
+                    "h1",
+                    "h2",
+                ): [(3.0 +2j, self.op1, self.op2)],
+                "h2": [(4.0 -5j, self.op2)],
+            }
+        ).transpose()
+
+        targ_transpose = MixedOp(
+            {
+                ("h1",): [(2.0 + 1j, self.op1.transpose())],
+                (
+                    "h1",
+                    "h2",
+                ): [(3.0 + 2j, self.op1.transpose(), self.op2.transpose())],
+                "h2": [(4.0 - 5j, self.op2.transpose())],
+            }
+        )
+        self.assertEqual(test_transpose, targ_transpose)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

This draft PR introduces a MixedOp for manipulating systems corresponding to various "local" Hilbert spaces.
The MixedMapper is also drafted to map this operator into a sum of qubit operators acting on the composed registers.

- [ ] `simplify()` method for the addition: should perform the factorization `op1 @ op2 + op1 @ op2' => op1 @ (op2 + op2') `   
- [ ] Simplification for the products: not in the form of an additional method but rather directly at the construction. Should simplify product of operators where multiple terms are in the same Hilbert space. (the operator product in H1 should replace the tensor product in H1xH1.
- [ ] Dealing with parameters was not tested.
- [ ] Serialization of these objects need to be addressed.
- [ ] Similarly, the str and repr remain to be properly implemented.

### Details and comments

See the tests and the following gist for checking the functionalities. [link](https://gist.github.com/Anthony-Gandon/5a7f9bf627e2cc14ce9f28e8141b9a1f)

